### PR TITLE
Cater for pip >= 10 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,11 @@ Created on Dec 2, 2015
 '''
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+
 
 install_reqs = parse_requirements("requirements.txt", session=False)
 reqs = [str(ir.req) for ir in install_reqs]


### PR DESCRIPTION
pip.req package was removed in v10